### PR TITLE
Fix platf

### DIFF
--- a/feedme.py
+++ b/feedme.py
@@ -588,7 +588,8 @@ def get_feed(feedname, cache, last_time, msglog):
     if not title:
         msglog.msg(sitefeedurl + " lacks a title!")
         feed.feed.title = '[' + feedname + ']'
-
+    
+    feedcachedict = []
     if cache and not nocache:
         try:
             feedcachedict = cache.thedict[sitefeedurl]

--- a/feedme.py
+++ b/feedme.py
@@ -18,7 +18,7 @@
 # <http://www.gnu.org/licenses/>.
 
 from __future__ import print_function
-
+import platform
 
 ConfigHelp = """Configuration options:
 
@@ -1632,9 +1632,19 @@ Use -N to re-load all previously cached stories and reinitialize the cache.
         # sys.exit(e.errno)
 
     try:
+        # Close the log file before trying to rename it (needed on Windows)
+        if platform.system() == 'Windows':
+            outputlog.close()
+            sys.stderr = stderrsav
+        
         # Now we're done. It's time to move the log file into its final place.
         datestr = time.strftime("%m-%d-%a")
         datedir = os.path.join(feeddir, datestr)
+
+        # create the datedir if needed:
+        if not os.path.exists(datedir):
+            os.makedirs(datedir)
+
         print("Renaming", logfilename, "to", os.path.join(datedir, 'LOG'),
               file=sys.stderr)
         os.rename(logfilename,

--- a/pageparser.py
+++ b/pageparser.py
@@ -76,7 +76,7 @@ class FeedmeURLDownloader(object):
             # In file:, allow for relative filenames even though that's not
             # part of the real file:// spec, to make testing a little easier.
             filename = url[7:]
-            with open(filename) as fp:
+            with open(filename, encoding='utf-8') as fp:
                 return fp.read()
 
         request = urllib.request.Request(url)

--- a/test/test_feedme.py
+++ b/test/test_feedme.py
@@ -69,13 +69,13 @@ class TestCaseWithSave(unittest.TestCase):
            newfile is the file just generated; expectfile will have XXXDAYXXX
            replace with today's day name (e.g. Fri).
         """
-        with open(expectfile) as expectfp:
+        with open(expectfile, encoding='utf-8') as expectfp:
             # The generated HTML file will have the weekday set to today.
             # The test file has a placeholder that needs to be replaced.
             today = datetime.now().strftime("%a")
             expectcontents = expectfp.read().replace('XXXDAYXXX', today)
 
-        with open(newfile) as newfp:
+        with open(newfile, encoding='utf-8') as newfp:
             newcontents = newfp.read()
 
         return expectcontents, newcontents


### PR DESCRIPTION
In this PR I fixed the errors I reported in the issue #1:

- **UnboundLocalError**: initialized `feedcachedict` before using it.
- **Windows log handling**: closed the log file before renaming it and ensured the target directory is created if it doesn’t exist.
- **Encoding issues**: explicitly opened files with `encoding="utf-8"` in both `pageparser.py` and the tests to avoid `UnicodeDecodeError` on Windows.

These changes make the project work on Windows, while keeping compatibility with macOS and Linux.